### PR TITLE
Fixed usage of flatten! and uniq! functions

### DIFF
--- a/controls/V-2230.rb
+++ b/controls/V-2230.rb
@@ -103,7 +103,8 @@ control 'V-2230' do
       dirs.push(location.params['root']) unless location.params['root'].nil?
     end
 
-    dirs.flatten!.uniq!
+    dirs.flatten!
+    dirs.uniq!
 
     dirs.each do |dir|
       next unless directory(dir).exist?

--- a/controls/V-2256.rb
+++ b/controls/V-2256.rb
@@ -165,7 +165,8 @@ control "V-2256" do
       webserver_roots.push(location.params['root']) unless location.params['root'].nil?
     end
 
-    webserver_roots.flatten!.uniq!
+    webserver_roots.flatten!
+    webserver_roots.uniq!
 
     webserver_roots.each do |directory|
       describe file(directory) do

--- a/controls/V-26305.rb
+++ b/controls/V-26305.rb
@@ -109,7 +109,8 @@ control "V-26305" do
       webserver_roots.push(location.params['root']) unless location.params['root'].nil?
     end
 
-    webserver_roots.flatten!.uniq!
+    webserver_roots.flatten!
+    webserver_roots.uniq!
 
     describe file(nginx_conf_handle.params['pid'].join) do
       it { should exist }

--- a/controls/V-6577.rb
+++ b/controls/V-6577.rb
@@ -101,7 +101,8 @@ control "V-6577" do
       webserver_roots.push(location.params['root']) unless location.params['root'].nil?
     end
 
-    webserver_roots.flatten!.uniq!
+    webserver_roots.flatten!
+    webserver_roots.uniq!
 
     services = command('systemctl list-unit-files --type service').stdout.scan(/^(.+).service/).flatten
 


### PR DESCRIPTION
Previous code ignores the fact that `flatten!` can return `nil`